### PR TITLE
Argo workflow namespace annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ kind: Component
 metadata:
   name: backstage
   annotations:
-    backstage.io/kubernetes-namespace: default
+    argo-workflows.cnoe.io/namespace: default
     argo-workflows.cnoe.io/label-selector: env=dev,my=label
 spec:
   type: service
@@ -172,7 +172,7 @@ kubernetes:
           caData: LS0t
 ```
 
-For this configuration, the `argo-workflows/cluster-name` annotaton value must be `my-cluster-1`
+For this configuration, the `argo-workflows.cnoe.io/cluster-name` annotaton value must be `my-cluster-1`
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
@@ -180,9 +180,26 @@ kind: Component
 metadata:
   name: backstage
   annotations:
-    backstage.io/kubernetes-namespace: default
+    argo-workflows.cnoe.io/namespace: default
     argo-workflows.cnoe.io/label-selector: env=dev,my=label
-    argo-workflows/cluster-name: my-cluster-1
+    argo-workflows.cnoe.io/cluster-name: my-cluster-1
+spec:
+  type: service
+  lifecycle: experimental
+  owner: user1
+  system: system1
+```
+
+If we remove the `argo-workflows.cnoe.io/namespace` annotation, it will show all label matched workflows across all namespaces.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  annotations:
+    argo-workflows.cnoe.io/label-selector: env=dev,my=label
+    argo-workflows.cnoe.io/cluster-name: my-cluster-1
 spec:
   type: service
   lifecycle: experimental

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -2,7 +2,7 @@ import {Entity} from "@backstage/catalog-model";
 import {
   ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION,
   CLUSTER_NAME_ANNOTATION,
-  K8S_NAMESPACE_ANNOTATION,
+  ARGO_WORKFLOWS_NAMESPACE_ANNOTATION,
 } from "../plugin";
 
 export function trimBaseUrl(argoWorkflowsBaseUrl: string | undefined) {
@@ -19,10 +19,7 @@ export type getAnnotationValuesOutput = {
 };
 
 export function getAnnotationValues(entity: Entity): getAnnotationValuesOutput {
-  const ns =
-    entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION] !== undefined
-      ? entity.metadata.annotations?.[K8S_NAMESPACE_ANNOTATION]
-      : "default";
+  const ns = entity.metadata.annotations?.[ARGO_WORKFLOWS_NAMESPACE_ANNOTATION];
   const clusterName = entity.metadata.annotations?.[CLUSTER_NAME_ANNOTATION];
   const labelSelector = entity.metadata?.annotations?.[ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION]
   return {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import {ArgoWorkflows, argoWorkflowsApiRef} from "./api";
 import {kubernetesApiRef} from "@backstage/plugin-kubernetes";
 
 export const CLUSTER_NAME_ANNOTATION = "argo-workflows.cnoe.io/cluster-name";
-export const K8S_NAMESPACE_ANNOTATION = "backstage.io/kubernetes-namespace";
+export const ARGO_WORKFLOW_NAMESPACE_ANNOTATION = "argo-workflows.cnoe.io/namespace";
 export const ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION =
   "argo-workflows.cnoe.io/label-selector";
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import {ArgoWorkflows, argoWorkflowsApiRef} from "./api";
 import {kubernetesApiRef} from "@backstage/plugin-kubernetes";
 
 export const CLUSTER_NAME_ANNOTATION = "argo-workflows.cnoe.io/cluster-name";
-export const ARGO_WORKFLOW_NAMESPACE_ANNOTATION = "argo-workflows.cnoe.io/namespace";
+export const ARGO_WORKFLOWS_NAMESPACE_ANNOTATION = "argo-workflows.cnoe.io/namespace";
 export const ARGO_WORKFLOWS_LABEL_SELECTOR_ANNOTATION =
   "argo-workflows.cnoe.io/label-selector";
 


### PR DESCRIPTION
Currently ArgoWorkflows plugin is leveraging "backstage.io/kubernetes-namespace" annotation to search for workflows based on label selector, so we have added argo workflows specific namespace annotation to have the plugin search for specified namespace, if we dont annotate namespace, it will search across the namesapces.